### PR TITLE
[Rental] getDaysRentedLimit 메서드 논리 오류 및 중복 로직 수정

### DIFF
--- a/src/Customer.java
+++ b/src/Customer.java
@@ -45,15 +45,7 @@ public class Customer {
 		for (Rental each : rentals) {
 			double eachCharge = 0;
 			int eachPoint = 0 ;
-			int daysRented = 0;
-
-			if (each.getStatus() == 1) { // returned Video
-				long diff = each.getReturnDate().getTime() - each.getRentDate().getTime();
-				daysRented = (int) (diff / (1000 * 60 * 60 * 24)) + 1;
-			} else { // not yet returned
-				long diff = new Date().getTime() - each.getRentDate().getTime();
-				daysRented = (int) (diff / (1000 * 60 * 60 * 24)) + 1;
-			}
+			int daysRented = each.getDaysRented();
 
 			switch (each.getVideo().getPriceCode()) {
 			case Video.REGULAR:

--- a/src/Rental.java
+++ b/src/Rental.java
@@ -50,14 +50,7 @@ public class Rental {
 
 	public int getDaysRentedLimit() {
 		int limit = 0 ;
-		int daysRented ;
-		if (getStatus() == 1) { // returned Video
-			long diff = returnDate.getTime() - rentDate.getTime();
-			daysRented = (int) (diff / (1000 * 60 * 60 * 24)) + 1;
-		} else { // not yet returned
-			long diff = new Date().getTime() - rentDate.getTime();
-			daysRented = (int) (diff / (1000 * 60 * 60 * 24)) + 1;
-		}
+		int daysRented = getDaysRented();
 		if ( daysRented <= 2) return limit ;
 
 		switch ( video.getVideoType() ) {
@@ -66,5 +59,15 @@ public class Rental {
 			case Video.DVD: limit = 2 ; break ;
 		}
 		return limit ;	
+	}
+
+	public int getDaysRented() {
+		long diff;
+		if (getStatus() == 1) {
+			diff = returnDate.getTime() - rentDate.getTime();
+		} else {
+			diff = new Date().getTime() - rentDate.getTime();
+		}
+		return ((int) (diff / (1000 * 60 * 60 * 24)) + 1);
 	}
 }

--- a/src/Rental.java
+++ b/src/Rental.java
@@ -49,16 +49,13 @@ public class Rental {
 	}
 
 	public int getDaysRentedLimit() {
-		int limit = 0 ;
-		int daysRented = getDaysRented();
-		if ( daysRented <= 2) return limit ;
-
-		switch ( video.getVideoType() ) {
-			case Video.VHS: limit = 5 ; break ;
-			case Video.CD: limit = 3 ; break ;
-			case Video.DVD: limit = 2 ; break ;
-		}
-		return limit ;	
+		int limit = switch (video.getVideoType()) {
+            case Video.VHS -> 5;
+            case Video.CD -> 3;
+            case Video.DVD -> 2;
+            default -> 0;
+        };
+        return limit;
 	}
 
 	public int getDaysRented() {


### PR DESCRIPTION
close #2 

- Rental.getDatedRented() 메서드를 통해 대여 기간을 구할 수 있게 수정
- 비디오 타입에 따라서 대여 기한이 올바르게 반환되도록 수정
- Customer에서 대여 기간을 구하기 위해 copy & paste 되어있던 코드를 제거하고 Rental.getDatedRented()로 대체